### PR TITLE
Rit Init

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,10 @@ fn main() {
 
             add_rit(paths);
         }
-        Some(("init", _)) => init_rit(),
+        Some(("init", _)) => match init_rit() {
+            Ok(_) => println!("rit initalized!"),
+            Err(e) => println!("{:?}", e.to_string()),
+        },
         _ => unreachable!(),
     }
 }

--- a/src/ops/init.rs
+++ b/src/ops/init.rs
@@ -1,8 +1,20 @@
-use std::fs;
+use std::io::{self, Error, ErrorKind};
+use std::{fs, path::Path};
 
-pub fn init_rit() {
-    match fs::create_dir_all(".rit/objects") {
-        Ok(_) => {}
-        Err(e) => println!("{e:?}"),
-    }
+pub fn init_rit() -> io::Result<()> {
+    let parent_dir = Path::new(".rit");
+
+    if parent_dir.exists() {
+        return Err(Error::new(
+            ErrorKind::AlreadyExists,
+            "rit already initialized in this dir",
+        ));
+    };
+
+    fs::create_dir_all(".rit/objects")?;
+    fs::create_dir(".rit/hooks")?;
+    fs::create_dir(".rit/info")?;
+    fs::create_dir(".rit/logs")?;
+    fs::create_dir(".rit/refs")?;
+    fs::create_dir(".rit/rr-cache")
 }


### PR DESCRIPTION
# Overview

Introduces the freature of `init` for our `rit` application. It initializes the app in the current directory similar to git.x
